### PR TITLE
Fixes a NameError from Slack::Api::Configuration

### DIFF
--- a/lib/slack/api.rb
+++ b/lib/slack/api.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../connection', __FILE__)
 require File.expand_path('../request', __FILE__)
+require File.expand_path('../configuration', __FILE__)
 
 module Slack
   # @private


### PR DESCRIPTION
Backtrace: 

```
/home/nemo/.rvm/gems/ruby-2.0.0-p481/gems/slack-api-0.0.2/lib/slack/api.rb:8:in `<class:API>': uninitialized constant Slack::API::Configuration (NameError)
        from /home/nemo/.rvm/gems/ruby-2.0.0-p481/gems/slack-api-0.0.2/lib/slack/api.rb:6:in `<module:Slack>'
        from /home/nemo/.rvm/gems/ruby-2.0.0-p481/gems/slack-api-0.0.2/lib/slack/api.rb:4:in `<top (required)>'
        from /home/nemo/.rvm/gems/ruby-2.0.0-p481@global/gems/bundler-1.6.2/lib/bundler/runtime.rb:85:in `require'
        from /home/nemo/.rvm/gems/ruby-2.0.0-p481@global/gems/bundler-1.6.2/lib/bundler/runtime.rb:85:in `rescue in block in require'
        from /home/nemo/.rvm/gems/ruby-2.0.0-p481@global/gems/bundler-1.6.2/lib/bundler/runtime.rb:68:in `block in require'
        from /home/nemo/.rvm/gems/ruby-2.0.0-p481@global/gems/bundler-1.6.2/lib/bundler/runtime.rb:61:in `each'
        from /home/nemo/.rvm/gems/ruby-2.0.0-p481@global/gems/bundler-1.6.2/lib/bundler/runtime.rb:61:in `require'
        from /home/nemo/.rvm/gems/ruby-2.0.0-p481@global/gems/bundler-1.6.2/lib/bundler.rb:132:in `require'
        from /home/nemo/projects/personal/amon/config/application.rb:7:in `<top (required)>'
```

This came from just requiring the gem, so I'm pretty sure its not an integration fault. If there is a better solution, please use that.
