### PR TITLE
Update the API at the date of today (commit date)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,5 @@
 require "bundler/gem_tasks"
+
+task :test do
+  sh "ruby spec/test.rb"
+end

--- a/lib/slack/client.rb
+++ b/lib/slack/client.rb
@@ -1,17 +1,43 @@
 module Slack
   class Client < API
-    METHODS = %w(users.info users.list channels.history channels.join
-                channels.mark channels.list files.upload files.list
-                im.history im.list groups.history groups.list
-                search.all search.files search.messages
-                chat.postMessage auth.test)
 
-    def respond_to?(method)
-      return METHODS.include?(method.id2name.gsub("_", ".")) || super
+    def self.prefix(prefix)
+      Proc.new do |e|
+        "#{prefix}.#{e}"
+      end
     end
 
-    def method_missing(action, *args)
-      post(action.id2name.gsub("_", "."), *args)
+    API_METHODS     = %w(test).map! &prefix('api')
+    AUTH_METHODS    = %w(test).map! &prefix('auth')
+    CHANNEL_METHODS = %w(archive create history info invite join kick leave list
+                         mark rename setPurpose setTopic unarchive
+                        ).map! &prefix('channels')
+    CHAT_METHODS    = %w(delete postMessage update).map! &prefix('chat')
+    EMOJI_METHODS   = %w(list).map! &prefix('emoji')
+    FILES_METHODS   = %w(info list upload).map! &prefix('files')
+    GROUPS_METHODS  = %w(archive close create createChild history invite kick
+                         leave list mark open rename setPurpose setTopic
+                         unarchive
+                        ).map! &prefix('groups')
+    IM_METHODS      = %w(close history list mark open).map! &prefix('im')
+    OAUTH_METHODS   = %w(access).map! &prefix('oauth')
+    RTM_METHODS     = %w(start).map! &prefix('rtm')
+    SEARCH_METHODS  = %w(all files messages).map! &prefix('search')
+    STARS_METHODS   = %w(list).map! &prefix('stars')
+    USERS_METHODS   = %w(getPresence info list setActive setPresence
+                        ).map! &prefix('users')
+
+    METHODS = [API_METHODS, AUTH_METHODS, CHANNEL_METHODS, CHAT_METHODS,
+               EMOJI_METHODS, FILES_METHODS, GROUPS_METHODS, IM_METHODS,
+               RTM_METHODS, SEARCH_METHODS, STARS_METHODS, USERS_METHODS].flatten
+
+    def base_method(action, *args)
+      post(action, *args)
     end
+
+    METHODS.map do |meth|
+      define_method(meth.gsub('.', '_').to_sym) {|*args| base_method(meth, *args)}
+    end
+
   end
 end

--- a/lib/slack/version.rb
+++ b/lib/slack/version.rb
@@ -1,3 +1,3 @@
 module Slack
-  VERSION = "0.0.4"
+  VERSION = "1.0.0"
 end

--- a/slack.gemspec
+++ b/slack.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rspec", "~> 2.4"
   spec.add_development_dependency "webmock", "~> 1.6" 
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'colored'
   spec.add_runtime_dependency "faraday", [">= 0.7", "<= 0.9"] 
   spec.add_runtime_dependency "faraday_middleware", "~> 0.8"
   spec.add_runtime_dependency "multi_json", ">= 1.0.3", "~> 1.0" 

--- a/spec/test.rb
+++ b/spec/test.rb
@@ -1,0 +1,34 @@
+require 'colored'
+require_relative '../lib/slack'
+
+s = Slack::Client.new
+s.token = '' # request a token on https://api.slack.com/web#basics
+
+if s.token == ''
+  raise "Undefined token ! Please set a token in spec/test.rb to run the tests."
+end
+
+FAILING_ERRORS = [
+  "restricted_action",
+  "not_authed",
+  "invalid_auth",
+  "account_inactive"
+]
+
+width = 3 + Slack::Client::METHODS.map(&:length).max
+all_true = true
+
+puts "Trying all the methods one by one..."
+Slack::Client::METHODS.each do |meth|
+  print "* #{meth.to_s.bold.yellow} "
+  print '.' * (width - meth.length)
+
+  res = s.base_method meth
+  is_ok = res['ok'] || not(FAILING_ERRORS.include? res['error'])
+  all_true &&= is_ok
+
+  puts "[#{is_ok ? "OK".green : "NO".red}]"
+  p res unless is_ok
+end
+
+raise "Some error happenned !" unless all_true

--- a/spec/test.rb
+++ b/spec/test.rb
@@ -9,6 +9,10 @@ if s.token == ''
 end
 
 FAILING_ERRORS = [
+  # this is really the error we want to test to
+  "unknown_method",
+  # the others are auth errors which make the test failing because of
+  # a misconfiguration, not a code error.
   "restricted_action",
   "not_authed",
   "invalid_auth",


### PR DESCRIPTION
Changes:
- Update all the method with https://api.slack.com/methods at the date of today
- BREAKING CHANGE: methods are now defined in the Client class rather than use
  the hacky #missing_method
- Provide a testing utility (needs to add a slack token)
- Fix gem dependency (rake was missing)

As the gem works well, I bumped the version to 1.0. I hope you don't mind this jump. ;)