### PR TITLE
updates faraday dependency to allow newer versions

### DIFF
--- a/slack.gemspec
+++ b/slack.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "json-schema"
   spec.add_development_dependency "pry"
 
-  spec.add_runtime_dependency "faraday", [">= 0.7", "<= 0.9"]
+  spec.add_runtime_dependency "faraday", [">= 0.7", "<= 0.9.9"]
   spec.add_runtime_dependency "faraday_middleware", "~> 0.8"
   spec.add_runtime_dependency "multi_json", ">= 1.0.3", "~> 1.0"
   spec.add_runtime_dependency "faye-websocket", "~> 0.9.2"


### PR DESCRIPTION
I set it to 0.9.9 because I was using the [upworthy](https://github.com/upworthy/slack-ruby-gem) fork and it seemed to work. I'm using faraday version 0.9.1 and haven't seen any problems.