### PR TITLE
Add options to allow for supplying ca_path and ca_file to Faraday

### DIFF
--- a/lib/slack/configuration.rb
+++ b/lib/slack/configuration.rb
@@ -34,7 +34,7 @@ module Slack
     DEFAULT_USER_AGENT = "Slack Ruby Gem #{Slack::VERSION}".freeze
 
     # Default openssl CA PATH
-    DEFAULT_CA_PATH = system("openssl version -a | grep OPENSSLDIR | awk '{print $2}'|sed -e 's/\"//g'")
+    DEFAULT_CA_PATH = %x[ openssl version -a | grep OPENSSLDIR | awk '{print $2}'|sed -e 's/\"//g' ]
 
     # @private
     attr_accessor *VALID_OPTIONS_KEYS

--- a/lib/slack/configuration.rb
+++ b/lib/slack/configuration.rb
@@ -10,7 +10,8 @@ module Slack
       :token,
       :endpoint,
       :user_agent,
-      :proxy
+      :proxy,
+      :ca_path
     ].freeze
 
     # The adapter that will be used to connect if none is set
@@ -31,6 +32,9 @@ module Slack
 
     # The user agent that will be sent to the API endpoint if none is set
     DEFAULT_USER_AGENT = "Slack Ruby Gem #{Slack::VERSION}".freeze
+
+    # Default openssl CA PATH
+    DEFAULT_CA_PATH = system("openssl version -a | grep OPENSSLDIR | awk '{print $2}'|sed -e 's/\"//g'")
 
     # @private
     attr_accessor *VALID_OPTIONS_KEYS
@@ -59,6 +63,7 @@ module Slack
       self.endpoint   = DEFAULT_ENDPOINT
       self.user_agent = DEFAULT_USER_AGENT
       self.proxy      = DEFAULT_PROXY
+      self.ca_path    = DEFAULT_CA_PATH
     end
   end
 end

--- a/lib/slack/configuration.rb
+++ b/lib/slack/configuration.rb
@@ -11,7 +11,8 @@ module Slack
       :endpoint,
       :user_agent,
       :proxy,
-      :ca_path
+      :ca_path,
+      :ca_file
     ].freeze
 
     # The adapter that will be used to connect if none is set
@@ -33,8 +34,9 @@ module Slack
     # The user agent that will be sent to the API endpoint if none is set
     DEFAULT_USER_AGENT = "Slack Ruby Gem #{Slack::VERSION}".freeze
 
-    # Default openssl CA PATH
+    # Default openssl CA_PATH and CA_FILE path
     DEFAULT_CA_PATH = %x[ openssl version -a | grep OPENSSLDIR | awk '{print $2}'|sed -e 's/\"//g' ]
+    DEFAULT_CA_FILE = "#{DEFAULT_CA_PATH}/ca-certificates.crt"
 
     # @private
     attr_accessor *VALID_OPTIONS_KEYS
@@ -64,6 +66,7 @@ module Slack
       self.user_agent = DEFAULT_USER_AGENT
       self.proxy      = DEFAULT_PROXY
       self.ca_path    = DEFAULT_CA_PATH
+      self.ca_file    = DEFAULT_CA_FILE
     end
   end
 end

--- a/lib/slack/connection.rb
+++ b/lib/slack/connection.rb
@@ -11,7 +11,7 @@ module Slack
         :headers => {'Accept' => "application/json; charset=utf-8", 'User-Agent' => user_agent},
         :proxy => proxy,
         :url => endpoint,
-        :ssl => { :ca_path => ca_path },
+        :ssl => { :ca_path => ca_path, :ca_file => ca_file },
       }
 
       Faraday::Connection.new(options) do |connection|

--- a/lib/slack/connection.rb
+++ b/lib/slack/connection.rb
@@ -11,6 +11,7 @@ module Slack
         :headers => {'Accept' => "application/json; charset=utf-8", 'User-Agent' => user_agent},
         :proxy => proxy,
         :url => endpoint,
+        :ca_path => ca_path,
       }
 
       Faraday::Connection.new(options) do |connection|

--- a/lib/slack/connection.rb
+++ b/lib/slack/connection.rb
@@ -11,7 +11,7 @@ module Slack
         :headers => {'Accept' => "application/json; charset=utf-8", 'User-Agent' => user_agent},
         :proxy => proxy,
         :url => endpoint,
-        :ca_path => ca_path,
+        :ssl => { :ca_path => ca_path },
       }
 
       Faraday::Connection.new(options) do |connection|


### PR DESCRIPTION
This allows to add the Faraday options `ca_path` and `ca_file` to the `Slack.configure` constructor.

Is needed if deployed in environments such as Heroku: https://github.com/lostisland/faraday/wiki/Setting-up-SSL-certificates#heroku-fedora-centos