### PR TITLE
Adds groups.info method

### DIFF
--- a/lib/slack/endpoint/groups.rb
+++ b/lib/slack/endpoint/groups.rb
@@ -75,6 +75,19 @@ module Slack
       end
 
       #
+      # Returns information about a private group.
+      #
+      # @option options [group] :channel
+      #   Private group to find info for.
+      # @see https://api.slack.com/methods/groups.info
+      # @see https://github.com/slackhq/slack-api-docs/blob/master/methods/groups.info.md
+      # @see https://github.com/slackhq/slack-api-docs/blob/master/methods/groups.info.json
+      def groups_info(options={})
+        throw ArgumentError.new("Required arguments :channel missing") if options[:channel].nil?
+        post("groups.info", options)
+      end
+
+      #
       # Invites a user to a private group.
       #
       # @option options [group] :channel


### PR DESCRIPTION
This PR adds the [groups.info](https://api.slack.com/methods/groups.info) API method.