### PR TITLE
Should either the client or server close, we should stop EM

### DIFF
--- a/lib/slack/realtime/client.rb
+++ b/lib/slack/realtime/client.rb
@@ -31,7 +31,7 @@ module Slack
           end
 
           ws.on :close do |event|
-            ws = nil
+            EM.stop
           end
         end
       end


### PR DESCRIPTION
Rather than just set the websocket to `nil`, we should stop the EM event loop entirely.  Otherwise processes will just sit and nothing will be coming through.