### PR TITLE
Added Slack::RealTime::Client stop.

### DIFF
--- a/lib/slack/realtime/client.rb
+++ b/lib/slack/realtime/client.rb
@@ -4,6 +4,8 @@ require 'eventmachine'
 module Slack
   module RealTime
     class Client
+      attr_accessor :url
+
       def initialize(url)
         @url = url
         @callbacks ||= {}
@@ -14,14 +16,18 @@ module Slack
         @callbacks[type] << block
       end
 
+      def stop
+        @ws.close if @ws
+      end
+
       def start
         EM.run do
-          ws = Faye::WebSocket::Client.new(@url)
+          @ws = Faye::WebSocket::Client.new(@url)
 
-          ws.on :open do |event|
+          @ws.on :open do |event|
           end
 
-          ws.on :message do |event|
+          @ws.on :message do |event|
             data = JSON.parse(event.data)
             if !data["type"].nil? && !@callbacks[data["type"].to_sym].nil?
               @callbacks[data["type"].to_sym].each do |c|
@@ -30,7 +36,8 @@ module Slack
             end
           end
 
-          ws.on :close do |event|
+          @ws.on :close do |event|
+            @ws = nil
             EM.stop
           end
         end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,0 +1,35 @@
+require_relative './spec_helper'
+
+RSpec.describe Slack::RealTime::Client do
+  let(:url) { 'wss://ms174.slack-msgs.com/websocket/xyz' }
+  let(:client) { Slack::RealTime::Client.new(url) }
+  let(:ws) { double(Faye::WebSocket::Client) }
+  describe :initialize do
+    it 'sets url' do
+      expect(client.url).to eq url
+    end
+  end
+  describe :start do
+    before do
+      allow(EM).to receive(:run).and_yield
+      allow(Faye::WebSocket::Client).to receive(:new).and_return(ws)
+    end
+    it 'start' do
+      expect(ws).to receive(:on).with(:open)
+      expect(ws).to receive(:on).with(:message)
+      expect(ws).to receive(:on).with(:close)
+      client.start
+      expect(client.instance_variable_get('@ws')).to eq ws
+    end
+  end
+  describe :stop do
+    it 'can be invoked without start' do
+      client.stop
+    end
+    it 'closes and nils the websocket' do
+      client.instance_variable_set('@ws', ws)
+      expect(ws).to receive(:close)
+      client.stop
+    end
+  end
+end


### PR DESCRIPTION
This is related to https://github.com/aki017/slack-ruby-gem/issues/24, to test that I wanted to be able to cleanly shutdown my service from an API, so I had to implement `Slack::RealTime::Client#stop`.