### PR TITLE
Raise an exception on error in message body.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Slack.configure do |config|
   config.token = "YOUR_TOKEN"
 end
 
-Slack.auth_test
+Slack.auth_test!
 ```
 
 ## Contributing

--- a/lib/slack/endpoint/auth.rb
+++ b/lib/slack/endpoint/auth.rb
@@ -9,7 +9,7 @@ module Slack
       # @see https://api.slack.com/methods/auth.test
       # @see https://github.com/slackhq/slack-api-docs/blob/master/methods/auth.test.md
       # @see https://github.com/slackhq/slack-api-docs/blob/master/methods/auth.test.json
-      def auth_test(options={})
+      def auth_test!(options={})
         post("auth.test", options)
       end
 

--- a/lib/slack/error.rb
+++ b/lib/slack/error.rb
@@ -16,4 +16,7 @@ module Slack
 
   # Raised when a subscription payload hash is invalid
   class InvalidSignature < Error; end
+
+  # Raised when an error is returned in the response
+  class ErrorInResponse < StandardError; end
 end

--- a/lib/slack/request.rb
+++ b/lib/slack/request.rb
@@ -35,7 +35,9 @@ module Slack
           request.body = options unless options.empty?
         end
       end
-      return response.body
+      body = response.body
+      fail ErrorInResponse, body['error'] if body.is_a?(Hash) && !body['ok']
+      body
     end
   end
 end

--- a/spec/auth_spec.rb
+++ b/spec/auth_spec.rb
@@ -10,12 +10,9 @@ RSpec.describe Slack::Client, :vcr do
       end
 
       it "with invalid token" do
-        expect(
+        expect {
           invalid_client.auth_test
-        ).to include({
-          "ok" => false,
-          "error" => "invalid_auth"
-        })
+        }.to raise_error Slack::ErrorInResponse, "invalid_auth"
       end
     end
   end

--- a/spec/auth_spec.rb
+++ b/spec/auth_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe Slack::Client, :vcr do
     describe :test do
       it "with valid token" do
         expect(
-          valid_client.auth_test
+          valid_client.auth_test!
         ).to valid_response
       end
 
       it "with invalid token" do
         expect {
-          invalid_client.auth_test
+          invalid_client.auth_test!
         }.to raise_error Slack::ErrorInResponse, "invalid_auth"
       end
     end

--- a/spec/channels_spec.rb
+++ b/spec/channels_spec.rb
@@ -57,12 +57,9 @@ RSpec.describe Slack::Client, :vcr do
       end
 
       it "with taken name" do
-        response = valid_client.channels_create name: "general"
-
-        expect(response).to include({
-          "ok" => false,
-          "error" => "name_taken"
-        })
+        expect {
+          valid_client.channels_create name: "general"
+        }.to raise_error Slack::ErrorInResponse, "name_taken"
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,11 +34,11 @@ module Helpers
   end
 
   def test_user_id
-    @test_user_id ||= valid_client.auth_test["user_id"]
+    @test_user_id ||= valid_client.auth_test!["user_id"]
   end
 
   def test_user_name
-    @test_user_name ||= valid_client.auth_test["user"]
+    @test_user_name ||= valid_client.auth_test!["user"]
   end
 
   def another_user_name


### PR DESCRIPTION
Closes #17. Now all errors are handled the same way, and you don't have to check explicitly.