### PR TITLE
fix definition of respond_to?

### DIFF
--- a/lib/slack.rb
+++ b/lib/slack.rb
@@ -21,7 +21,7 @@ module Slack
   end
 
   # Delegate to Slack::Client
-  def self.respond_to?(method)
-    return client.respond_to?(method) || super
+  def self.respond_to?(method, include_all=false)
+    return client.respond_to?(method, include_all) || super
   end
 end


### PR DESCRIPTION
Since Ruby 2.0, `respond_to?` has an extra argument.  RSpec uses this
argument when mocking out a method.  Mocking out a method on `Slack` was
breaking because this argument was being passed, but was unexpected.