### PR TITLE
Remove the need to explicitly require slack.

### DIFF
--- a/lib/slack-api.rb
+++ b/lib/slack-api.rb
@@ -1,0 +1,1 @@
+require 'slack'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ SimpleCov.start do
   add_filter '.bundle/'
 end
 
-require 'slack'
+require 'slack-api'
 require 'webmock/rspec'
 require 'vcr'
 WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
Today if you want to use this gem you have to explicitly `require 'slack'`, this is annoying, so many people put this in Gemfile: `gem 'slack-api', require: 'slack'`, which is annoying too. We can just add a slack-api.rb and not need the above. This also follows the convention that you require the same name as the gem.

Fixes part of #14. 

