### PR TITLE
Convert an `attachments` option to the JSON format

### DIFF
--- a/lib/slack/api.rb
+++ b/lib/slack/api.rb
@@ -23,8 +23,8 @@ module Slack
     include Endpoint
 
     def realtime
-      url = post("rtm.start")["url"]
-      RealTime::Client.new(url)
+      rtm_start_response = post("rtm.start")
+      RealTime::Client.new(rtm_start_response)
     end
   end
 end

--- a/lib/slack/endpoint/chat.rb
+++ b/lib/slack/endpoint/chat.rb
@@ -50,6 +50,7 @@ module Slack
       def chat_postMessage(options={})
         throw ArgumentError.new("Required arguments :channel missing") if options[:channel].nil?
         throw ArgumentError.new("Required arguments :text missing") if options[:text].nil?
+        options[:attachments] = options[:attachments].to_json if options[:attachments].present?
         post("chat.postMessage", options)
       end
 

--- a/lib/slack/realtime/client.rb
+++ b/lib/slack/realtime/client.rb
@@ -4,8 +4,11 @@ require 'eventmachine'
 module Slack
   module RealTime
     class Client
-      def initialize(url)
-        @url = url
+      attr_reader :response
+
+      def initialize(rtm_start_response)
+        @response    = rtm_start_response
+        @url         = rtm_start_response["url"]
         @callbacks ||= {}
       end
 


### PR DESCRIPTION
Otherwise, the Slack API considers defined object as a string and eventually ignores it.