### PR TITLE
Convert an `attachments` option to the JSON format.

### DIFF
--- a/lib/slack/endpoint/chat.rb
+++ b/lib/slack/endpoint/chat.rb
@@ -50,6 +50,7 @@ module Slack
       def chat_postMessage(options={})
         throw ArgumentError.new("Required arguments :channel missing") if options[:channel].nil?
         throw ArgumentError.new("Required arguments :text missing") if options[:text].nil?
+        options[:attachments] = options[:attachments].to_json if options[:attachments].present?
         post("chat.postMessage", options)
       end
 


### PR DESCRIPTION
Otherwise, the Slack API considers defined object as a string and eventually ignores it.