### PR TITLE
Keep `rtm.start` response as a part of `RealTime::Client` instance.

### DIFF
--- a/lib/slack/api.rb
+++ b/lib/slack/api.rb
@@ -23,8 +23,8 @@ module Slack
     include Endpoint
 
     def realtime
-      url = post("rtm.start")["url"]
-      RealTime::Client.new(url)
+      rtm_start_response = post("rtm.start")
+      RealTime::Client.new(rtm_start_response)
     end
   end
 end

--- a/lib/slack/realtime/client.rb
+++ b/lib/slack/realtime/client.rb
@@ -4,8 +4,11 @@ require 'eventmachine'
 module Slack
   module RealTime
     class Client
-      def initialize(url)
-        @url = url
+      attr_reader :response
+
+      def initialize(rtm_start_response)
+        @response    = rtm_start_response
+        @url         = rtm_start_response["url"]
         @callbacks ||= {}
       end
 


### PR DESCRIPTION
Since it has a bunch of useful information alongside with url (such as an API user data, team info, channels list etc).

https://api.slack.com/methods/rtm.start
