### PR TITLE
Expose RTM socket.

### DIFF
--- a/spec/realtime_client_spec.rb
+++ b/spec/realtime_client_spec.rb
@@ -1,0 +1,33 @@
+require_relative './spec_helper'
+
+RSpec.describe Slack::RealTime::Client, vcr: { cassette_name: 'rtm.start' } do
+  let(:mock_socket) { double(Faye::WebSocket::Client, on: true) }
+  before do
+    allow(EM).to receive(:run).and_yield
+    allow(EM).to receive(:next_tick).and_yield
+  end
+  subject do
+    valid_client.realtime
+  end
+  it 'is not started by default' do
+    expect(subject.url).to eq 'wss://ms173.slack-msgs.com/websocket/xyz'
+    expect(subject).to_not be_started
+  end
+  describe 'started' do
+    before do
+      expect(Faye::WebSocket::Client).to receive(:new).and_return(mock_socket)
+      subject.start
+    end
+    it 'connects websocket' do
+      expect(subject).to be_started
+      expect(subject.url).to eq 'wss://ms173.slack-msgs.com/websocket/xyz'
+    end
+    describe 'send_data' do
+      it 'sends raw data' do
+        data = 'raw data'
+        expect(mock_socket).to receive(:send).with(data)
+        subject.send_data(data)
+      end
+    end
+  end
+end

--- a/spec/vcr/rtm_start.yml
+++ b/spec/vcr/rtm_start.yml
@@ -1,0 +1,370 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://slack.com/api/rtm.start
+    body:
+      encoding: UTF-8
+      string: token=<TOKEN>
+    headers:
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - Slack Ruby Gem 1.1.6
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, no-cache, no-store, must-revalidate
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Jul 2015 13:33:26 GMT
+      Expires:
+      - Mon, 26 Jul 1997 05:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Apache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      X-Accepted-Oauth-Scopes:
+      - client
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - identify,read,post,client
+      X-Xss-Protection:
+      - '0'
+      Content-Length:
+      - '3563'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{
+        "ok": true,
+        "self": {
+          "id": "U07KECJ77",
+          "name": "test",
+          "prefs": {
+            "highlight_words": "",
+            "user_colors": "",
+            "color_names_in_list": true,
+            "growls_enabled": true,
+            "tz": null,
+            "push_dm_alert": true,
+            "push_mention_alert": true,
+            "push_everything": true,
+            "push_idle_wait": 2,
+            "push_sound": "b2.mp3",
+            "push_loud_channels": "",
+            "push_mention_channels": "",
+            "push_loud_channels_set": "",
+            "email_alerts": "instant",
+            "email_alerts_sleep_until": 0,
+            "email_misc": true,
+            "email_weekly": true,
+            "welcome_message_hidden": false,
+            "all_channels_loud": true,
+            "loud_channels": "",
+            "never_channels": "",
+            "loud_channels_set": "",
+            "show_member_presence": true,
+            "search_sort": "timestamp",
+            "expand_inline_imgs": true,
+            "expand_internal_inline_imgs": true,
+            "expand_snippets": false,
+            "posts_formatting_guide": true,
+            "seen_welcome_2": false,
+            "seen_ssb_prompt": false,
+            "seen_spaces_new_xp_tooltip": false,
+            "spaces_new_xp_banner_dismissed": false,
+            "search_only_my_channels": false,
+            "emoji_mode": "default",
+            "emoji_use": "",
+            "has_invited": false,
+            "has_uploaded": false,
+            "has_created_channel": false,
+            "search_exclude_channels": "",
+            "messages_theme": "default",
+            "webapp_spellcheck": true,
+            "no_joined_overlays": false,
+            "no_created_overlays": false,
+            "dropbox_enabled": false,
+            "seen_domain_invite_reminder": false,
+            "seen_member_invite_reminder": false,
+            "mute_sounds": false,
+            "arrow_history": false,
+            "tab_ui_return_selects": true,
+            "obey_inline_img_limit": true,
+            "new_msg_snd": "knock_brush.mp3",
+            "collapsible": false,
+            "collapsible_by_click": true,
+            "require_at": false,
+            "ssb_space_window": "",
+            "mac_ssb_bounce": "",
+            "mac_ssb_bullet": true,
+            "expand_non_media_attachments": true,
+            "show_typing": true,
+            "pagekeys_handled": true,
+            "last_snippet_type": "",
+            "display_real_names_override": 0,
+            "time24": false,
+            "enter_is_special_in_tbt": false,
+            "graphic_emoticons": false,
+            "convert_emoticons": true,
+            "autoplay_chat_sounds": true,
+            "ss_emojis": true,
+            "sidebar_behavior": "",
+            "seen_onboarding_start": false,
+            "onboarding_cancelled": false,
+            "seen_onboarding_slackbot_conversation": false,
+            "seen_onboarding_channels": false,
+            "seen_onboarding_direct_messages": false,
+            "seen_onboarding_invites": false,
+            "seen_onboarding_search": false,
+            "seen_onboarding_recent_mentions": false,
+            "seen_onboarding_starred_items": false,
+            "seen_onboarding_private_groups": false,
+            "onboarding_slackbot_conversation_step": 0,
+            "mark_msgs_read_immediately": true,
+            "start_scroll_at_oldest": true,
+            "snippet_editor_wrap_long_lines": false,
+            "ls_disabled": false,
+            "sidebar_theme": "default",
+            "sidebar_theme_custom_values": "",
+            "f_key_search": false,
+            "k_key_omnibox": true,
+            "speak_growls": false,
+            "mac_speak_voice": "com.apple.speech.synthesis.voice.Alex",
+            "mac_speak_speed": 250,
+            "comma_key_prefs": false,
+            "at_channel_suppressed_channels": "",
+            "push_at_channel_suppressed_channels": "",
+            "prompted_for_email_disabling": false,
+            "full_text_extracts": false,
+            "no_text_in_notifications": false,
+            "muted_channels": "",
+            "no_macssb1_banner": false,
+            "no_winssb1_banner": false,
+            "no_omnibox_in_channels": false,
+            "k_key_omnibox_auto_hide_count": 0,
+            "privacy_policy_seen": true,
+            "search_exclude_bots": false,
+            "fuzzy_matching": false,
+            "load_lato_2": false,
+            "fuller_timestamps": false,
+            "last_seen_at_channel_warning": 0,
+            "flex_resize_window": false,
+            "msg_preview": false,
+            "msg_preview_displaces": true,
+            "msg_preview_persistent": true,
+            "emoji_autocomplete_big": false,
+            "winssb_run_from_tray": true,
+            "two_factor_auth_enabled": false,
+            "two_factor_type": null,
+            "mentions_exclude_at_channels": true,
+            "confirm_clear_all_unreads": true,
+            "confirm_user_marked_away": true,
+            "box_enabled": false,
+            "seen_single_emoji_msg": false,
+            "confirm_sh_call_start": true
+          },
+          "created": 1436893858,
+          "manual_presence": "active"
+        },
+        "team": {
+          "id": "T04KB5WQH",
+          "name": "example",
+          "email_domain": "example.org",
+          "domain": "exampledotorg",
+          "msg_edit_window_mins": -1,
+          "prefs": {
+            "default_channels": [
+              "C04KB5X4D",
+              "C04KB5X4Z"
+            ],
+            "msg_edit_window_mins": -1,
+            "allow_message_deletion": true,
+            "hide_referers": true,
+            "display_real_names": false,
+            "who_can_at_everyone": "regular",
+            "who_can_at_channel": "ra",
+            "warn_before_at_channel": "always",
+            "who_can_create_channels": "regular",
+            "who_can_archive_channels": "regular",
+            "who_can_create_groups": "ra",
+            "who_can_post_general": "ra",
+            "who_can_kick_channels": "admin",
+            "who_can_kick_groups": "regular",
+            "retention_type": 0,
+            "retention_duration": 0,
+            "group_retention_type": 0,
+            "group_retention_duration": 0,
+            "dm_retention_type": 0,
+            "dm_retention_duration": 0,
+            "file_retention_type": 0,
+            "file_retention_duration": 0,
+            "require_at_for_mention": 0,
+            "compliance_export_start": 0,
+            "auth_mode": "normal"
+          },
+          "icon": {
+            "image_34": "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2015-04-28/4657218807_d480d2ee610d2e8aacfe_34.jpg",
+            "image_44": "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2015-04-28/4657218807_d480d2ee610d2e8aacfe_44.jpg",
+            "image_original": "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2015-04-28/4657218807_d480d2ee610d2e8aacfe_original.jpg"
+          },
+          "over_storage_limit": false,
+          "plan": ""
+        },
+        "latest_event_ts": "1437744206.000000",
+        "channels": [
+          {
+            "id": "C06JKEMJ8",
+            "name": "demo",
+            "is_channel": true,
+            "created": 1434735992,
+            "creator": "U04KB5WQR",
+            "is_archived": false,
+            "is_general": false,
+            "has_pins": false,
+            "is_member": false
+          },
+          {
+            "id": "C04KB5X4D",
+            "name": "general",
+            "is_channel": true,
+            "created": 1430222230,
+            "creator": "U04KB5WQR",
+            "is_archived": false,
+            "is_general": true,
+            "has_pins": false,
+            "is_member": true,
+            "last_read": "1436471493.000033",
+            "latest": {
+              "type": "message",
+              "user": "U04KB5WQR",
+              "text": "test",
+              "ts": "1437675919.000050"
+            },
+            "unread_count": 159,
+            "unread_count_display": 139,
+            "members": [
+              "U04JPQ0JS",
+              "U07KECJ77"
+            ],
+            "topic": {
+              "value": "",
+              "creator": "",
+              "last_set": 0
+            },
+            "purpose": {
+              "value": "This channel is for team-wide communication and announcements. All team members are in this channel.",
+              "creator": "",
+              "last_set": 0
+            }
+          }
+        ],
+        "groups": [],
+        "ims": [
+          {
+            "id": "D07KE9GD9",
+            "is_im": true,
+            "user": "USLACKBOT",
+            "created": 1436893858,
+            "last_read": "0000000000.000000",
+            "latest": null,
+            "unread_count": 0,
+            "unread_count_display": 0,
+            "is_open": true
+          }
+        ],
+        "users": [
+          {
+            "id": "U07KECJ77",
+            "name": "test",
+            "deleted": false,
+            "status": null,
+            "color": "e96699",
+            "real_name": "Test User",
+            "tz": null,
+            "tz_label": "Pacific Daylight Time",
+            "tz_offset": -25200,
+            "profile": {
+              "bot_id": "B07KECJ6R",
+              "image_24": "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2015-07-14/test_24.jpg",
+              "image_32": "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2015-07-14/test_32.jpg",
+              "image_original": "https://s3-us-west-2.amazonaws.com/slack-files2/avatars/2015-07-14/test_original.jpg",
+              "first_name": "Joe",
+              "last_name": "Shmoe",
+              "real_name": "Joe Shmoe",
+              "real_name_normalized": "Joe Shmoe"
+            },
+            "is_admin": false,
+            "is_owner": false,
+            "is_primary_owner": false,
+            "is_restricted": false,
+            "is_ultra_restricted": false,
+            "is_bot": true,
+            "has_files": false,
+            "presence": "away"
+          },
+          {
+            "id": "USLACKBOT",
+            "name": "slackbot",
+            "deleted": false,
+            "status": null,
+            "color": "757575",
+            "real_name": "slackbot",
+            "tz": null,
+            "tz_label": "Pacific Daylight Time",
+            "tz_offset": -25200,
+            "profile": {
+              "first_name": "slackbot",
+              "last_name": "",
+              "image_24": "https://slack-assets2.s3-us-west-2.amazonaws.com/10068/img/slackbot_24.png",
+              "image_32": "https://slack-assets2.s3-us-west-2.amazonaws.com/10068/img/slackbot_32.png",
+              "image_48": "https://slack-assets2.s3-us-west-2.amazonaws.com/10068/img/slackbot_48.png",
+              "image_72": "https://slack-assets2.s3-us-west-2.amazonaws.com/10068/img/slackbot_72.png",
+              "image_192": "https://slack-assets2.s3-us-west-2.amazonaws.com/10068/img/slackbot_192.png",
+              "real_name": "slackbot",
+              "real_name_normalized": "slackbot",
+              "email": null
+            },
+            "is_admin": false,
+            "is_owner": false,
+            "is_primary_owner": false,
+            "is_restricted": false,
+            "is_ultra_restricted": false,
+            "is_bot": false,
+            "presence": "active"
+          }
+        ],
+        "cache_ts": 1437744806,
+        "cache_version": "v10-dog",
+        "bots": [
+          {
+            "id": "B04JPQ0JE",
+            "name": "bot",
+            "deleted": false,
+            "icons": {
+              "image_48": "https://slack.global.ssl.fastly.net/93ed/img/services/bots_48.png"
+            }
+          }
+        ],
+        "url": "wss://ms173.slack-msgs.com/websocket/xyz"
+      }'
+    http_version:
+  recorded_at: Fri, 24 Jul 2015 13:33:26 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
Right now you can only receive messages from the RTM API. We need to be able to also send them. With this change you can, for example, send a typing event:

```ruby
client = Slack.realtime

Thread.new do
   client.start
end

client.send_data({ type: 'typing', channel: data.channel }.to_json)
```

Update documentation and written basic RTM tests.