### PR TITLE
call callback when websocket is closed

### DIFF
--- a/lib/slack/realtime/client.rb
+++ b/lib/slack/realtime/client.rb
@@ -31,6 +31,11 @@ module Slack
           end
 
           ws.on :close do |event|
+            if !@callbacks[:close].nil?
+              @callbacks[:close].each do |c|
+                c.call
+              end
+            end
             EM.stop
           end
         end

--- a/lib/slack/realtime/client.rb
+++ b/lib/slack/realtime/client.rb
@@ -31,11 +31,7 @@ module Slack
           end
 
           ws.on :close do |event|
-            if !@callbacks[:close].nil?
-              @callbacks[:close].each do |c|
-                c.call
-              end
-            end
+            @callbacks[:close].each { |c| c.call } unless @callbacks[:close].nil?
             EM.stop
           end
         end


### PR DESCRIPTION
Changed to call `@callbacks[:close]` when connection is closed.
How about it?
