### PR TITLE
Only update api if specifes the name

### DIFF
--- a/lib/generators/tasks/generate.rb
+++ b/lib/generators/tasks/generate.rb
@@ -52,8 +52,18 @@ namespace :api do
     templete = Erubis::Eruby.new(File.read(templete_path))
 
     outpath = File.expand_path "lib/slack/endpoint.rb", root
-    FileUtils.rm_rf outpath
-    File.write outpath, templete.result(files: data.keys)
+    included_modules = File.read(outpath).scan(/include (.+)/).flatten.map(&:downcase)
+
+    if opts[:api_name]
+      if ! included_modules.include?(opts[:api_name])
+        included_modules << opts[:api_name]
+        FileUtils.rm_rf outpath
+        File.write outpath, templete.result(files: included_modules.sort)
+      end
+    else
+      FileUtils.rm_rf outpath
+      File.write outpath, templete.result(files: data.keys)
+    end
   end
 
   def generate_methods(data, opts)

--- a/lib/generators/tasks/generate.rb
+++ b/lib/generators/tasks/generate.rb
@@ -55,7 +55,8 @@ namespace :api do
     included_modules = File.read(outpath).scan(/include (.+)/).flatten.map(&:downcase)
 
     if opts[:api_name]
-      if ! included_modules.include?(opts[:api_name])
+      if data.keys.include?(opts[:api_name]) && \
+         !included_modules.include?(opts[:api_name])
         included_modules << opts[:api_name]
         FileUtils.rm_rf outpath
         File.write outpath, templete.result(files: included_modules.sort)

--- a/lib/generators/tasks/generate.rb
+++ b/lib/generators/tasks/generate.rb
@@ -54,10 +54,10 @@ namespace :api do
     outpath = File.expand_path "lib/slack/endpoint.rb", root
     included_modules = File.read(outpath).scan(/include (.+)/).flatten.map(&:downcase)
 
-    if opts[:api_name]
-      if data.keys.include?(opts[:api_name]) && \
-         !included_modules.include?(opts[:api_name])
-        included_modules << opts[:api_name]
+    if opts.api_name
+      if data.keys.include?(opts.api_name) && \
+         !included_modules.include?(opts.api_name)
+        included_modules << opts.api_name
         FileUtils.rm_rf outpath
         File.write outpath, templete.result(files: included_modules.sort)
       end
@@ -73,7 +73,7 @@ namespace :api do
 
     outdir = File.expand_path "lib/slack/endpoint", root
     data.each_with_index do |(group, names), index|
-      next if opts[:api_name] && opts[:api_name] != group
+      next if opts.api_name && opts.api_name != group
 
       printf "%2d/%2d %10s %s\n", index, data.size, group, names.keys
 

--- a/lib/generators/tasks/generate.rb
+++ b/lib/generators/tasks/generate.rb
@@ -62,6 +62,8 @@ namespace :api do
 
     outdir = File.expand_path "lib/slack/endpoint", root
     data.each_with_index do |(group, names), index|
+      next if opts[:api_name] && opts[:api_name] != group
+
       printf "%2d/%2d %10s %s\n", index, data.size, group, names.keys
 
       outpath = File.expand_path "#{group}.rb", outdir

--- a/lib/generators/tasks/generate.rb
+++ b/lib/generators/tasks/generate.rb
@@ -4,7 +4,7 @@ require 'erubis'
 
 namespace :api do
   desc "update"
-  task :update do
+  task :update, [:api_name] do |task, args|
     Dir.chdir root
     sh "git submodule update --init --recursive"
     sh "git submodule foreach git pull origin master"

--- a/lib/generators/tasks/generate.rb
+++ b/lib/generators/tasks/generate.rb
@@ -35,7 +35,7 @@ namespace :api do
     end
 
     generate_methods(data, args)
-    generate_endpoint(data)
+    generate_endpoint(data, args)
   end
 
   desc "Cleanup"
@@ -47,7 +47,7 @@ namespace :api do
     FileUtils.rm_rf outpath
   end
 
-  def generate_endpoint(data)
+  def generate_endpoint(data, opts)
     templete_path = File.expand_path 'lib/generators/templates/endpoint.rb.erb', root
     templete = Erubis::Eruby.new(File.read(templete_path))
 

--- a/lib/generators/tasks/generate.rb
+++ b/lib/generators/tasks/generate.rb
@@ -8,7 +8,7 @@ namespace :api do
     Dir.chdir root
     sh "git submodule update --init --recursive"
     sh "git submodule foreach git pull origin master"
-    Rake::Task["api:generate"].execute
+    Rake::Task["api:generate"].execute(args)
     sh "git add lib/slack/endpoint.rb"
     sh "git add lib/slack/endpoint/"
     sh "git add slack-api-docs"
@@ -16,7 +16,7 @@ namespace :api do
   end
 
   desc "Generate"
-  task :generate do
+  task :generate, [:api_name] do |task, args|
     jsons = File.expand_path 'slack-api-docs/methods/*.json', root
     schema_path = File.expand_path "lib/generators/schema.json", root
     schema = JSON.parse(File.read(schema_path))

--- a/lib/generators/tasks/generate.rb
+++ b/lib/generators/tasks/generate.rb
@@ -34,7 +34,7 @@ namespace :api do
 
     end
 
-    generate_methods(data)
+    generate_methods(data, args)
     generate_endpoint(data)
   end
 
@@ -56,7 +56,7 @@ namespace :api do
     File.write outpath, templete.result(files: data.keys)
   end
 
-  def generate_methods(data)
+  def generate_methods(data, opts)
     templete_path = File.expand_path 'lib/generators/templates/method.rb.erb', root
     templete = Erubis::Eruby.new(File.read(templete_path))
 

--- a/lib/generators/tasks/generate.rb
+++ b/lib/generators/tasks/generate.rb
@@ -29,7 +29,7 @@ namespace :api do
 
       parsed = JSON.parse(File.read(path))
       JSON::Validator.validate(schema, parsed, :insert_defaults => true)
- 
+
       result[prefix][name] = parsed
 
     end

--- a/lib/generators/tasks/generate.rb
+++ b/lib/generators/tasks/generate.rb
@@ -61,12 +61,11 @@ namespace :api do
     templete = Erubis::Eruby.new(File.read(templete_path))
 
     outdir = File.expand_path "lib/slack/endpoint", root
-    FileUtils.rm_rf outdir
-    FileUtils.mkdir outdir
     data.each_with_index do |(group, names), index|
       printf "%2d/%2d %10s %s\n", index, data.size, group, names.keys
 
       outpath = File.expand_path "#{group}.rb", outdir
+      File.delete(outpath) if File.exist?(outpath)
       File.write outpath, templete.result(group: group, names: names)
     end
   end

--- a/lib/generators/tasks/generate.rb
+++ b/lib/generators/tasks/generate.rb
@@ -1,3 +1,4 @@
+require 'bundler/setup'
 require 'json-schema'
 require 'erubis'
 


### PR DESCRIPTION
## The reason why I create this PR

Recently, updates https://github.com/aki017/slack-api-docs/commit/1ac07b4a9902bb1386d46ddaf484e754c6290429 by `aki017/slack-api-docs-generator`.

But [aki017/slack-ruby-gem](https://github.com/aki017/slack-ruby-gem) does not follow the latest [aki017/slack-api-docs](https://github.com/aki017/slack-api-docs/).  So if you execute `rake api:update`, creates too many diffs in one commit.

It's undesirable to revert api update if you failed.

I think that if `rake api:update` specifies api name, only update the api, so prevent the tragedy and you can more easily update [aki017/slack-ruby-gem](https://github.com/aki017/slack-ruby-gem) in stages

I hope that  [aki017/slack-ruby-gem](https://github.com/aki017/slack-ruby-gem) follows latest slack api as soon as possible.
## Usage

``` zsh
# No specifies the argument, update all.
$ rake api:update

# Specifies the api name, only updates the api.
$ rake 'api:update[channels]'
```
## What do I ask

What do you think this policy? Please let me oponion.
