### PR TITLE
Upgrade faraday version

### DIFF
--- a/slack.gemspec
+++ b/slack.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "json-schema"
   spec.add_development_dependency "pry"
 
-  spec.add_runtime_dependency "faraday", [">= 0.7", "< 0.10"]
+  spec.add_runtime_dependency "faraday", "~> 0.11"
   spec.add_runtime_dependency "faraday_middleware", "~> 0.8"
   spec.add_runtime_dependency "multi_json", ">= 1.0.3", "~> 1.0"
   spec.add_runtime_dependency "faye-websocket", "~> 0.9.2"


### PR DESCRIPTION
The current faraday version is out of date and blocking other gems to updates. 