### PR TITLE
Update faye-websocket dep

### DIFF
--- a/slack.gemspec
+++ b/slack.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "faraday", "~> 0.11"
   spec.add_runtime_dependency "faraday_middleware", "~> 0.10.0"
   spec.add_runtime_dependency "multi_json", ">= 1.0.3", "~> 1.0"
-  spec.add_runtime_dependency "faye-websocket", "~> 0.10.6"
+  spec.add_runtime_dependency "faye-websocket", "~> 0.11.0"
 end

--- a/slack.gemspec
+++ b/slack.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "bundler", "> 1.5"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "coveralls"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
Tests still pass. Required to address this vulnerability: https://github.com/advisories/GHSA-2v5c-755p-p4gv